### PR TITLE
Fix Seurat Import

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,6 +2,7 @@
 ^\.Rproj\.user$
 ^\.travis\.yml$
 ^build_whitelist.sh$
+^build_site.sh$
 ^docs/.*$
 ^vignettes/web_only/.*$
 ^.*.eslintrc.json

--- a/build_site.sh
+++ b/build_site.sh
@@ -1,0 +1,2 @@
+R -e "devtools::document()"
+R -e "pkgdown::build_site(document = FALSE, examples = FALSE, preview = FALSE)"

--- a/docs/articles/web_only/Seurat.html
+++ b/docs/articles/web_only/Seurat.html
@@ -121,17 +121,14 @@
 <h2 class="hasAnchor">
 <a href="#how-this-works" class="anchor"></a>How this works</h2>
 <ul>
-<li>If <code>obj@scale.data</code> exists, this is used as the expression data.
-<ul>
-<li>Otherwise, <code>obj@data</code> is used if “NormalizeData” was previously run.</li>
-<li>If “NormalizeData” was not run, then <code>obj@raw.data</code> is used (after scaling the expression sum in each cell to the median)</li>
-</ul>
-</li>
+<li>By default, <code>assay = "RNA"</code>, though this parameter is configurable.</li>
+<li>
+<code>obj@[[assay]]@counts</code> is used as the expression input (after normalizing to a library size of 10,000)</li>
 <li>The cell meta-data is taken from <code>obj@meta.data</code>
 </li>
-<li>Lower-dimensional visualizations are taken from the first 2 components of every “Dimensionality Reduction” in <code>object@dr</code>
+<li>Lower-dimensional visualizations are taken each dimensionality reduction in <code>Reductions(obj)</code>
 <ul>
-<li>These are added using their names prefixed with “Seurat_”</li>
+<li>These are added using their original names prefixed with “Seurat_”</li>
 </ul>
 </li>
 <li>If “pca” has been run, the latentSpace input is taken from its associated cell embeddings
@@ -142,6 +139,19 @@
 </ul>
 </li>
 </ul>
+<div id="recommendations-when-using-seurat-integratedata" class="section level3">
+<h3 class="hasAnchor">
+<a href="#recommendations-when-using-seurat-integratedata" class="anchor"></a>Recommendations when using Seurat <code>IntegrateData</code>
+</h3>
+<p>When using <code>IntegrateData</code>, a new assay is created called <code>integrated</code>.</p>
+<p>We recommend creating your reduced-dimensional representation using this assay by running PCA in Seurat after <code>IntegrateData</code>.</p>
+<p>Then create the Vision object, but use the default <code>assay="RNA"</code>.</p>
+<ul>
+<li>The original (normalized) counts will be used as the expression input</li>
+<li>However, the integrated latent space will be used to create the neighbors graph</li>
+</ul>
+<p>Why not use the integrated expression data? Typically this data only consists of a subset of the genes (e.g. 2000 highly-variable genes) and so is not ideal for matching genes in signatures.</p>
+</div>
 </div>
 <div id="examples" class="section level2">
 <h2 class="hasAnchor">

--- a/docs/reference/VISION-class.html
+++ b/docs/reference/VISION-class.html
@@ -166,7 +166,7 @@ expression data, meta-data, and dimensionality reductions if they exist already<
 <span class='fu'>Vision</span>(<span class='no'>data</span>, <span class='kw'>signatures</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/list'>list</a></span>(),
   <span class='kw'>proteinData</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>unnormalizedData</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>meta</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>projection_genes</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"fano"</span>), <span class='kw'>min_signature_genes</span> <span class='kw'>=</span> <span class='fl'>5</span>,
-  <span class='kw'>sig_gene_threshold</span> <span class='kw'>=</span> <span class='fl'>0.005</span>, <span class='kw'>threshold</span> <span class='kw'>=</span> <span class='fl'>0.05</span>, <span class='kw'>perm_wPCA</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
+  <span class='kw'>sig_gene_threshold</span> <span class='kw'>=</span> <span class='fl'>0.001</span>, <span class='kw'>threshold</span> <span class='kw'>=</span> <span class='fl'>0.05</span>, <span class='kw'>perm_wPCA</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
   <span class='kw'>projection_methods</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"tSNE30"</span>),
   <span class='kw'>sig_norm_method</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"znorm_columns"</span>, <span class='st'>"none"</span>, <span class='st'>"znorm_rows"</span>,
   <span class='st'>"znorm_rows_then_columns"</span>, <span class='st'>"rank_norm_columns"</span>), <span class='kw'>pool</span> <span class='kw'>=</span> <span class='st'>"auto"</span>,
@@ -194,8 +194,8 @@ expression data, meta-data, and dimensionality reductions if they exist already<
   <span class='no'>...</span>)
 
 <span class='co'># S4 method for Seurat</span>
-<span class='fu'>Vision</span>(<span class='no'>data</span>, <span class='kw'>dimRed</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>dimRedComponents</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='no'>...</span>)</pre>
+<span class='fu'>Vision</span>(<span class='no'>data</span>, <span class='kw'>assay</span> <span class='kw'>=</span> <span class='st'>"RNA"</span>, <span class='kw'>dimRed</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='kw'>dimRedComponents</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='no'>...</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -325,6 +325,10 @@ look for "pca" and use that if it exists</p></td>
       <th>dimRedComponents</th>
       <td><p>number of components to use for the selected dimensionality
 reduction.  Default is to use all components</p></td>
+    </tr>
+    <tr>
+      <th>assay</th>
+      <td><p>The assay slot in the Seurat object to use for expression data</p></td>
     </tr>
     <tr>
       <th>dimRed</th>

--- a/man/VISION-class.Rd
+++ b/man/VISION-class.Rd
@@ -18,7 +18,7 @@ Vision(data, ...)
 \S4method{Vision}{matrixORSparse}(data, signatures = list(),
   proteinData = NULL, unnormalizedData = NULL, meta = NULL,
   projection_genes = c("fano"), min_signature_genes = 5,
-  sig_gene_threshold = 0.005, threshold = 0.05, perm_wPCA = FALSE,
+  sig_gene_threshold = 0.001, threshold = 0.05, perm_wPCA = FALSE,
   projection_methods = c("tSNE30"),
   sig_norm_method = c("znorm_columns", "none", "znorm_rows",
   "znorm_rows_then_columns", "rank_norm_columns"), pool = "auto",
@@ -39,8 +39,8 @@ Vision(data, ...)
 \S4method{Vision}{seurat}(data, dimRed = NULL, dimRedComponents = NULL,
   ...)
 
-\S4method{Vision}{Seurat}(data, dimRed = NULL, dimRedComponents = NULL,
-  ...)
+\S4method{Vision}{Seurat}(data, assay = "RNA", dimRed = NULL,
+  dimRedComponents = NULL, ...)
 }
 \arguments{
 \item{data}{expression data - can be one of these: \itemize{
@@ -124,6 +124,8 @@ look for "pca" and use that if it exists}
 
 \item{dimRedComponents}{number of components to use for the selected dimensionality
 reduction.  Default is to use all components}
+
+\item{assay}{The assay slot in the Seurat object to use for expression data}
 
 \item{dimRed}{Dimensionality reduction to use for the latentSpace.  Default is to
 look for "pca" and use that if it exists}

--- a/vignettes/web_only/Seurat.Rmd
+++ b/vignettes/web_only/Seurat.Rmd
@@ -6,16 +6,28 @@ If you are already using Seurat for your analysis, VISION provides a convenience
 
 ## How this works
 
-* If `obj@scale.data` exists, this is used as the expression data.
-  * Otherwise, `obj@data` is used if "NormalizeData" was previously run.
-  * If "NormalizeData" was not run, then `obj@raw.data` is used (after scaling the expression sum in each cell to the median)
+* By default, `assay = "RNA"`, though this parameter is configurable.
+* `obj@[[assay]]@counts` is used as the expression input (after normalizing to a library size of 10,000)
 * The cell meta-data is taken from `obj@meta.data`
-* Lower-dimensional visualizations are taken from the first 2 components of every "Dimensionality Reduction" in `object@dr`
-  * These are added using their names prefixed with "Seurat\_"
+* Lower-dimensional visualizations are taken each dimensionality reduction in `Reductions(obj)`
+  * These are added using their original names prefixed with "Seurat\_"
 * If "pca" has been run, the latentSpace input is taken from its associated cell embeddings
   * The `dimRed` parameter can be used to select a different dimensionality reduction for this
   * The `dimRedComponents` can be used to limit the number of components used (Default: All components)
   * Otherwise, VISION computes the latentSpace by running PCA internally
+
+### Recommendations when using Seurat `IntegrateData`
+
+When using `IntegrateData`, a new assay is created called `integrated`.
+
+We recommend creating your reduced-dimensional representation using this assay by running PCA in Seurat after `IntegrateData`.
+
+Then create the Vision object, but use the default `assay="RNA"`.
+
+* The original (normalized) counts will be used as the expression input
+* However, the integrated latent space will be used to create the neighbors graph
+
+Why not use the integrated expression data?  Typically this data only consists of a subset of the genes (e.g. 2000 highly-variable genes) and so is not ideal for matching genes in signatures.
 
 ## Examples
 


### PR DESCRIPTION
Needed to fix how Seurat is importing data - the @scale.data slot is unsuitable as it has already been centered (and therefore can't be turned back into linear-scale data with an inverse log1p).