### PR TITLE
Fix NAs cells in DE from selections

### DIFF
--- a/R/Server.R
+++ b/R/Server.R
@@ -953,8 +953,8 @@ launchServer <- function(object, port=NULL, host=NULL, browser=TRUE) {
             cluster_denom <- match(cells_denom, colnames(exprDataSubset))
 
             # Needed for sparse subsetting
-            cluster_num <- as.numeric(cluster_num)
-            cluster_denom <- as.numeric(cluster_denom)
+            cluster_num <- na.omit(as.numeric(cluster_num))
+            cluster_denom <- na.omit(as.numeric(cluster_denom))
 
             out <- matrix_wilcox_cpp(exprDataSubset, cluster_num, cluster_denom)
 


### PR DESCRIPTION
NAs were causing an error in DE from selection of cells that are in the UMAP or tree but not in both.

This omits those NA values.

Would need version update in s133 for live version.