### PR TITLE
Add Seurat DE Tests

### DIFF
--- a/inst/html_output/Results.html
+++ b/inst/html_output/Results.html
@@ -236,6 +236,29 @@
                                         <input type="number" id="de_sub_cells_n" class="form-control" tabindex="-1" value="1000"></input>
                                     </div>
                                 </div>
+                                
+                                <div>
+                                    <div class='label-control no-select' style="align-items: center">
+                                        <span class="label">
+                                            <label for="de_test_type">DE Test Type</label>
+                                        </span>
+                                    </div>
+                                    <div class='label-control max-control'>
+                                        <select id="de_test_type" class="form-control">
+                                            <option value="wilcox">Default (Fast Wilcoxon Rank Sum)</option>
+                                            <option value="swilcox">Wilcoxon Rank Sum (Seurat)</option>
+                                            <option value="sbimod">Bimodal (Seurat)</option>
+                                            <option value="sroc">AUCROC (Seurat)</option>
+                                            <option value="st">T-test (Seurat)</option>
+                                            <option value="spoisson">Poisson (Seurat)</option>
+                                            <option value="snegbinom">Negative Binomial (Seurat)</option>
+                                            <option value="slr">Logistic Regression (Seurat)</option>
+                                            <option value="smast">MAST (Seurat)</option>
+                                            <option value="sdeseq2">DESeq2 (Seurat)</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                
                               </div>
                           </div>
   

--- a/inst/html_output/Results.html
+++ b/inst/html_output/Results.html
@@ -246,14 +246,14 @@
                                     <div class='label-control max-control'>
                                         <select id="de_test_type" class="form-control">
                                             <option value="wilcox">Default (Fast Wilcoxon Rank Sum)</option>
-                                            <option value="swilcox">Wilcoxon Rank Sum (Seurat)</option>
-                                            <option value="sbimod">Bimodal (Seurat)</option>
+                                            <option value="swilcox" disabled="">Wilcoxon Rank Sum (Seurat)</option>
+                                            <option value="sbimod" disabled>Bimodal (Seurat)</option>
                                             <!-- <option value="sroc">AUCROC (Seurat)</option>-->
-                                            <option value="st">T-test (Seurat)</option>
+                                            <option value="st" disabled>T-test (Seurat)</option>
                                             <!-- <option value="spoisson">Poisson (Seurat)</option>-->
                                             <!-- <option value="snegbinom">Negative Binomial (Seurat)</option>-->
-                                            <option value="slr">Logistic Regression (Seurat)</option>
-                                            <option value="smast">MAST (Seurat)</option>
+                                            <option value="slr" disabled>Logistic Regression (Seurat)</option>
+                                            <!-- <option value="smast">MAST (Seurat)</option> -->
                                             <!-- <option value="sdeseq2">DESeq2 (Seurat)</option> -->
                                         </select>
                                     </div>

--- a/inst/html_output/Results.html
+++ b/inst/html_output/Results.html
@@ -248,13 +248,13 @@
                                             <option value="wilcox">Default (Fast Wilcoxon Rank Sum)</option>
                                             <option value="swilcox">Wilcoxon Rank Sum (Seurat)</option>
                                             <option value="sbimod">Bimodal (Seurat)</option>
-                                            <option value="sroc">AUCROC (Seurat)</option>
+                                            <!-- <option value="sroc">AUCROC (Seurat)</option>-->
                                             <option value="st">T-test (Seurat)</option>
-                                            <option value="spoisson">Poisson (Seurat)</option>
-                                            <option value="snegbinom">Negative Binomial (Seurat)</option>
+                                            <!-- <option value="spoisson">Poisson (Seurat)</option>-->
+                                            <!-- <option value="snegbinom">Negative Binomial (Seurat)</option>-->
                                             <option value="slr">Logistic Regression (Seurat)</option>
                                             <option value="smast">MAST (Seurat)</option>
-                                            <option value="sdeseq2">DESeq2 (Seurat)</option>
+                                            <!-- <option value="sdeseq2">DESeq2 (Seurat)</option> -->
                                         </select>
                                     </div>
                                 </div>

--- a/inst/html_output/src/api.js
+++ b/inst/html_output/src/api.js
@@ -175,14 +175,13 @@ var api = (function(){
         return $.ajax(query, {dataType: "json"}).then(x => x)
     }
 
-    //Yanay
-    output.de = function(type_n, subtype_n, group_num, type_d, subtype_d, group_denom, min_cells, subsample_groups, subsample_N) {
+    output.de = function(type_n, subtype_n, group_num, type_d, subtype_d, group_denom, min_cells, subsample_groups, subsample_N, de_test_type) {
         var query = "DE"
 
         query = postProcess(query)
         return $.ajax(query, {
             type: "POST",
-            data: JSON.stringify({"type_n":type_n, "type_d":type_d, "subtype_n":subtype_n, "subtype_d":subtype_d,  "group_num":group_num, "group_denom":group_denom, "min_cells":min_cells, "subsample_groups":subsample_groups, "subsample_N":subsample_N}),
+            data: JSON.stringify({"type_n":type_n, "type_d":type_d, "subtype_n":subtype_n, "subtype_d":subtype_d,  "group_num":group_num, "group_denom":group_denom, "min_cells":min_cells, "subsample_groups":subsample_groups, "subsample_N":subsample_N, "de_test_type":de_test_type}),
             dataType: "json"
         }).then(x => x);
     }

--- a/inst/html_output/src/main.js
+++ b/inst/html_output/src/main.js
@@ -251,6 +251,12 @@ window.onload = function()
                 .find(".nav-link[data-main-vis='genes']")
                 .removeClass('disabled')
         }
+        
+        
+        if(info.has_seurat){
+            // Enable all seurat options
+            $('#de_test_type > option').prop("disabled", false)
+        }
 
         global_data.meta_sigs = info.meta_sigs
         global_status.pooled = info.pooled

--- a/inst/html_output/src/upper_left_content.js
+++ b/inst/html_output/src/upper_left_content.js
@@ -1624,6 +1624,7 @@ function DE_Select()
     this.min_cells = $(this.dom_node).find('#de_min_cells');
     this.sub_cells_n = $(this.dom_node).find('#de_sub_cells_n');
     this.sub_cells = $(this.dom_node).find('#de_sub_cells');
+    this.de_test_type = $(this.dom_node).find('#de_test_type');
 }
 
 DE_Select.prototype.init = function()
@@ -1786,10 +1787,12 @@ DE_Select.prototype.init = function()
 
         var subtype_n = ""
         var subtype_d = ""
+        
 
         var min_cells = self.min_cells.val();
         var sub_cells_n = self.sub_cells_n.val();
-        var sub_cells = self.sub_cells.is(":checked")
+        var sub_cells = self.sub_cells.is(":checked");
+        var de_test_type = self.de_test_type.val();
 
         if (!min_cells) {
             min_cells = 0;
@@ -1845,7 +1848,7 @@ DE_Select.prototype.init = function()
         api.de(
             type_n, subtype_n, group_num,
             type_d, subtype_d, group_denom,
-            min_cells, sub_cells, sub_cells_n
+            min_cells, sub_cells, sub_cells_n, de_test_type
         ).then(data => {
             set_global_status({"de":data})
         });

--- a/inst/html_output/src/upper_left_content.js
+++ b/inst/html_output/src/upper_left_content.js
@@ -1651,12 +1651,11 @@ DE_Select.prototype.init = function()
                 {'title': 'Feature'},
                 {'title': 'Type'},
                 {'title': 'logFC'},
-                {'title': 'AUC'},
                 {'title': 'FDR'},
             ],
             "pageLength": 500,
             "scrollY": '15vh',
-            "order": [[4, "asc"]],
+            "order": [[3, "asc"]],
             "buttons": {
                 dom: {
                     button: {
@@ -1977,10 +1976,9 @@ DE_Select.prototype.render_de = function()
     var features = get_global_status('de')["Feature"]
     var types = get_global_status('de')["Type"]
     var pvals = get_global_status('de')["pval"]
-    var stats = get_global_status('de')["stat"]
     var logFCs = get_global_status('de')["logFC"]
 
-    var dataSet = _.map(features, (f, i) => [features[i], types[i], logFCs[i], stats[i], pvals[i]]);
+    var dataSet = _.map(features, (f, i) => [features[i], types[i], logFCs[i], pvals[i]]);
 
     this.de_results.show();
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // geary
 double geary(NumericVector X, NumericMatrix W);
 RcppExport SEXP _VISION_geary(SEXP XSEXP, SEXP WSEXP) {


### PR DESCRIPTION
Adds advanced option selector for DE to use Seurat DE tests.

Note: call `library(Seurat)` before viewing/serving report. The default method is much faster since it is in C.