### PR TITLE
Add download button to UI

### DIFF
--- a/R/Server.R
+++ b/R/Server.R
@@ -1429,7 +1429,25 @@ launchServer <- function(object, port=NULL, host=NULL, browser=TRUE) {
         res$body <- "null"  # Empty body for successful POST
         return(res)
     })
+    
 
+    pr$handle("GET", "/Download/DE", function(req, res) {
+                res$headers[["Content-Disposition"]] <- "attachment; filename=vision_de.json"
+                res$headers[["fileName"]] <- "vision_de.json"
+                res$headers[["Cache-Control"]] <- NULL
+                #res$headers[["fileName"]] <- "vision_de.json"
+                # print(object@Viewer$de_cache)
+                object@Viewer$de_cache
+              })
+    
+    pr$handle("GET", "/Download/Selections", function(req, res) {
+        res$headers[["Content-Disposition"]] <- "attachment; filename=vision_selections.json"
+        res$headers[["Cache-Control"]] <- NULL
+        res$headers[["fileName"]] <- "vision_selections.json"
+        #res$headers[["fileName"]] <- "vision_selections.json"
+        # print(getSelections(object))
+        getSelections(object)
+      })
     # Assume all other paths are files or 404
 
     pr$filter("filterFilter", function(req, res) {

--- a/R/Server.R
+++ b/R/Server.R
@@ -1432,20 +1432,17 @@ launchServer <- function(object, port=NULL, host=NULL, browser=TRUE) {
     
 
     pr$handle("GET", "/Download/DE", function(req, res) {
-                res$headers[["Content-Disposition"]] <- "attachment; filename=vision_de.json"
-                res$headers[["fileName"]] <- "vision_de.json"
+                res$headers[["Content-Disposition"]] <- "attachment; filename=de.json"
+                res$headers[["fileName"]] <- "de.json"
                 res$headers[["Cache-Control"]] <- NULL
-                #res$headers[["fileName"]] <- "vision_de.json"
-                # print(object@Viewer$de_cache)
+                
                 object@Viewer$de_cache
               })
     
     pr$handle("GET", "/Download/Selections", function(req, res) {
-        res$headers[["Content-Disposition"]] <- "attachment; filename=vision_selections.json"
+        res$headers[["Content-Disposition"]] <- "attachment; filename=selections.json"
         res$headers[["Cache-Control"]] <- NULL
-        res$headers[["fileName"]] <- "vision_selections.json"
-        #res$headers[["fileName"]] <- "vision_selections.json"
-        # print(getSelections(object))
+        res$headers[["fileName"]] <- "selections.json"
         getSelections(object)
       })
     # Assume all other paths are files or 404

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -1171,3 +1171,25 @@ depth_first_traverse_nodes <- function(tree, postorder=T) {
     }
     return(traversal)
 }
+
+#' Add a de cache json object (downloaded from server) to vision object
+#' 
+#' @param object the vision object
+#' @param json_file_path path to json object for DE file downloaded from "Download" button
+#' @return the modified vision object
+load_de_cache <- function(object, json_file_path) {
+  de_json <- fromJSON(json_file_path)
+  object@Viewer$de_cache <- de_json
+  return(object)
+}
+
+#' Add selections json object (downloaded from server) to vision object
+#' 
+#' @param object the vision object
+#' @param json_file_path path to json object for selections file downloaded from "Download" button
+#' @return the modified vision object
+load_selections <- function(object, json_file_path) {
+  selections_json <- fromJSON(json_file_path)
+  object@Viewer$selections <- selections_json
+  return(object)
+}

--- a/inst/html_output/Results.html
+++ b/inst/html_output/Results.html
@@ -510,10 +510,10 @@
                             </div>
                         </div>
                         <div id="export-object">
-                            <div class="label">Save Object</div>
+                            <div class="label">Save Report Info</div>
                             <div style="display: flex;">
                                 <button id="export-object-button" type="button" class="btn btn-outline-secondary"
-                                    style="margin-left: 5px" >Download</button>
+                                    style="margin-left: 5px" data-toggle="modal" data-target="#saveObjectModal">Download</button>
                             </div>
                         </div>
                     </div>
@@ -578,7 +578,31 @@
       </div>
     </div>
     <!-- End Save Selection Modal -->
-
+    <!-- Download Object Modal -->
+    <div class="modal fade" id="saveObjectModal" tabindex="-1" role="dialog" aria-labelledby="saveObjectModalTitle" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="saveObjectModalTitle">Download Vision Object</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+              <div class="form-group">
+                  <label for="saveObjectName">File names prefix</label>
+                  <input type="text" class="form-control" id="saveObjectName" area-describedby="selectionObjectHelp"></input>
+                  <small id="selectionObjectHelp" class="form-text text-muted" default="vision">Pick a prefix to be added the downloaded file names.</small>
+              </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-primary confirm-button">Download</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- End Save Object Modal -->
     <!-- Load Selection Modal -->
     <div class="modal fade" id="loadSelectionModal" tabindex="-1" role="dialog" aria-labelledby="loadSelectionModalTitle" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered" role="document">

--- a/inst/html_output/Results.html
+++ b/inst/html_output/Results.html
@@ -509,6 +509,13 @@
                                     data-toggle="modal" data-target="#loadSelectionModal" style="margin-left: 5px" >Load</button>
                             </div>
                         </div>
+                        <div id="export-object">
+                            <div class="label">Save Object</div>
+                            <div style="display: flex;">
+                                <button id="export-object-button" type="button" class="btn btn-outline-secondary"
+                                    style="margin-left: 5px" >Download</button>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div id="scatter-container-div">

--- a/inst/html_output/Results.html
+++ b/inst/html_output/Results.html
@@ -592,7 +592,7 @@
               <div class="form-group">
                   <label for="saveObjectName">File names prefix</label>
                   <input type="text" class="form-control" id="saveObjectName" area-describedby="selectionObjectHelp"></input>
-                  <small id="selectionObjectHelp" class="form-text text-muted" default="vision">Pick a prefix to be added the downloaded file names.</small>
+                  <small id="selectionObjectHelp" class="form-text text-muted" default="vision">Pick a prefix to be added before the downloaded file names.</small>
               </div>
           </div>
           <div class="modal-footer">

--- a/inst/html_output/src/api.js
+++ b/inst/html_output/src/api.js
@@ -398,7 +398,20 @@ var api = (function(){
         query = postProcess(query)
         return $.ajax(query, {dataType: "json"}).then(x => x)
     }
-
+    
+    // Download
+    
+    output.downloadDE = function() {
+        var query = "Download/DE"
+        query = postProcess(query)
+        return $.ajax(query, {dataType: "blob"}).then(x => x)
+    }
+    
+    output.downloadSelections = function() {
+        var query = "Download/Selections"
+        query = postProcess(query)
+        return $.ajax(query, {dataType: "blob"}).then(x => x)
+    }
     // Session Info Api
 
     output.sessionInfo = function() {

--- a/inst/html_output/src/api.js
+++ b/inst/html_output/src/api.js
@@ -399,19 +399,6 @@ var api = (function(){
         return $.ajax(query, {dataType: "json"}).then(x => x)
     }
     
-    // Download
-    
-    output.downloadDE = function() {
-        var query = "Download/DE"
-        query = postProcess(query)
-        return $.ajax(query, {dataType: "blob"}).then(x => x)
-    }
-    
-    output.downloadSelections = function() {
-        var query = "Download/Selections"
-        query = postProcess(query)
-        return $.ajax(query, {dataType: "blob"}).then(x => x)
-    }
     // Session Info Api
 
     output.sessionInfo = function() {

--- a/inst/html_output/src/right_content.js
+++ b/inst/html_output/src/right_content.js
@@ -6,7 +6,34 @@ Right_Content.prototype.init = function()
 {
     var self = this;
     self.dom_node = $("#right-content");
+    
+    // Download
 
+    self.download_button = $("#export-object-button")
+    // https://stackoverflow.com/a/42830315
+    function downloadFile(urlToSend) {
+      var req = new XMLHttpRequest();
+      req.open("GET", urlToSend, true);
+      req.responseType = "blob";
+      req.onload = function (event) {
+         var blob = req.response;
+         var fileName = req.getResponseHeader("filename") //if you have the fileName header available
+         var link=document.createElement('a');
+         link.href=window.URL.createObjectURL(blob);
+         link.download=fileName;
+         link.click();
+      };
+      
+      req.send();
+    }
+    self.download_button.click(function() {
+      // selections call
+      downloadFile("/Download/Selections")
+      // de call
+      downloadFile("/Download/DE")
+    });
+    // End download button
+    
     self.scatterColorOptions = $(self.dom_node).find("input[name='scatterColorButtons']")
     self.scatterLayoutOptions = $(self.dom_node).find("input[name='scatterLayoutButtons']")
 
@@ -91,7 +118,7 @@ Right_Content.prototype.init = function()
     }
 
     self.dom_node.get(0).addEventListener('scatter_relayout', _scatter_relayout)
-
+    
     // Allow for clicking to specify selected plot div
     $(self.dom_node).find(".scatter-split-plot-div")
         .on('click', function(e){

--- a/inst/html_output/src/right_content.js
+++ b/inst/html_output/src/right_content.js
@@ -26,11 +26,28 @@ Right_Content.prototype.init = function()
       
       req.send();
     }
+    
+    // https://stackoverflow.com/a/30800715
+    function downloadObjectAsJson(exportObj, exportName){
+      var dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(exportObj));
+      var downloadAnchorNode = document.createElement('a');
+      downloadAnchorNode.setAttribute("href",     dataStr);
+      downloadAnchorNode.setAttribute("download", exportName + ".json");
+      document.body.appendChild(downloadAnchorNode); // required for firefox
+      downloadAnchorNode.click();
+      downloadAnchorNode.remove();
+    }
     self.download_button.click(function() {
       // selections call
       downloadFile("/Download/Selections")
       // de call
       downloadFile("/Download/DE")
+      // download the current scatter plot's data
+      var scatter_json = _.cloneDeep(self.getSelectedPlotData())
+      // included the selected cells
+      scatter_json["selected_cells"] = get_global_status("selected_cell")
+      delete scatter_json["scatter"]
+      downloadObjectAsJson(scatter_json, "vision_scatter")
     });
     // End download button
     

--- a/inst/html_output/src/right_content.js
+++ b/inst/html_output/src/right_content.js
@@ -43,7 +43,7 @@ Right_Content.prototype.init = function()
       // de call
       downloadFile("/Download/DE")
       // download the current scatter plot's data
-      var scatter_json = _.cloneDeep(self.getSelectedPlotData())
+      var scatter_json = _.cloneDeep(right_content.getSelectedPlotData())
       // included the selected cells
       scatter_json["selected_cells"] = get_global_status("selected_cell")
       delete scatter_json["scatter"]

--- a/inst/html_output/src/right_content.js
+++ b/inst/html_output/src/right_content.js
@@ -8,16 +8,19 @@ Right_Content.prototype.init = function()
     self.dom_node = $("#right-content");
     
     // Download
+    // Set up events for downloading object
+    var saveObjectModal = $('#saveObjectModal')
 
+    
     self.download_button = $("#export-object-button")
     // https://stackoverflow.com/a/42830315
-    function downloadFile(urlToSend) {
+    function downloadFile(urlToSend, file_name) {
       var req = new XMLHttpRequest();
       req.open("GET", urlToSend, true);
       req.responseType = "blob";
       req.onload = function (event) {
          var blob = req.response;
-         var fileName = req.getResponseHeader("filename") //if you have the fileName header available
+         var fileName = file_name + "_" +req.getResponseHeader("filename")
          var link=document.createElement('a');
          link.href=window.URL.createObjectURL(blob);
          link.download=fileName;
@@ -37,18 +40,22 @@ Right_Content.prototype.init = function()
       downloadAnchorNode.click();
       downloadAnchorNode.remove();
     }
-    self.download_button.click(function() {
-      // selections call
-      downloadFile("/Download/Selections")
-      // de call
-      downloadFile("/Download/DE")
-      // download the current scatter plot's data
-      var scatter_json = _.cloneDeep(right_content.getSelectedPlotData())
-      // included the selected cells
-      scatter_json["selected_cells"] = get_global_status("selected_cell")
-      delete scatter_json["scatter"]
-      downloadObjectAsJson(scatter_json, "vision_scatter")
-    });
+ 
+    saveObjectModal.find(".confirm-button").on("click", function() {
+        var prefix = $('#saveObjectName').val()
+        // selections call
+        downloadFile("/Download/Selections", prefix)
+        // de call
+        downloadFile("/Download/DE", prefix)
+        // download the current scatter plot's data
+        var scatter_json = _.cloneDeep(right_content.getSelectedPlotData())
+        // included the selected cells
+        scatter_json["selected_cells"] = get_global_status("selected_cell")
+        delete scatter_json["scatter"]
+        downloadObjectAsJson(scatter_json, prefix + "_scatter")
+        saveObjectModal.modal('hide')
+    })
+    
     // End download button
     
     self.scatterColorOptions = $(self.dom_node).find("input[name='scatterColorButtons']")


### PR DESCRIPTION
Downloads 2 files

- `vision_de.json`
- `vision_selection.json`
- `vision_scatter.json`

The first two files can be added to a vision object in R using the corresponding functions
- `load_de_cache`
- `load_selections`

After using those two functions, a subsequent call to `viewResults` will retain those user selections and de cache results.

Example workflow:

1. User creates and saves selections in viewer. 
2. User calculates various DE calls.
3. User pressed download button and gets both files.
4. User creates a new vision object with those values with the following code:
```
vis_new <- load_de_cache(vis, "de_cache_download_path")
vis_new <- load_selections(vis, "selections_download_path")
```
5. User launches/hosts a new server with those selections and cache defaulted using `viewResults(vis_new)'

The final file, `vision_scatter.json` contains information about the values being plotted when the user pressed the download button.

This file has the following keys:
`"item_key"        "item_type"       "values"          "needsUpdate"     "projection"      "projection_type"
"projection_keyX" "projection_keyY" "selected_cells" `

- `projection` has the XY coordinates
- `item_key` has the name of the plotted values, `item_type` has the type
- `values` has the plotted values
- `projection_keyX` and `projection_keyY` have the x and y axis labels
- `selected_cells` has a list of which cells are selected at the time of download