### PR TITLE
implemented entropy calculation into user report

### DIFF
--- a/R/Server.R
+++ b/R/Server.R
@@ -1412,16 +1412,24 @@ launchServer <- function(object, port=NULL, host=NULL, browser=TRUE) {
 
         metaSummaryFactor <-
             lapply(metaSubset[!numericMeta], function(item){
-               vals <- sort(table(droplevels(item)),
-                            decreasing = TRUE)
-               vals <- vals / length(item) * 100
-               return(as.list(vals))
+                vals <- sort(table(droplevels(item)),
+                            decreasing = TRUE) # top factor
+                vals <- vals / length(item) * 100 # percent
+
+                if (length(unique(item)) == 1) {
+                    entropy <- 0
+                } else {
+                    frequencies <- table(as.character(item)) / length(item)
+                    entropy <- -sum(frequencies * log2(frequencies))
+                }
+
+               return(list(levels=as.list(vals), entropy=entropy))
             })
 
         metaSummary <- list(numeric = metaSummaryNumeric,
                             factor = metaSummaryFactor
                            )
-
+        
         res$body <- toJSON(
             metaSummary, force = TRUE, pretty = TRUE,
             auto_unbox = TRUE, digits = I(4)

--- a/inst/html_output/src/lower_left_content.js
+++ b/inst/html_output/src/lower_left_content.js
@@ -673,10 +673,12 @@ Selection_Info.prototype.init = function()
             {'title': 'Categorical Variables', 'data': 'Variable'},
             {'title': 'Top Value', 'data': 'TopValue'},
             {'title': 'Percent', 'data': 'Percent', 'render': p => p.toFixed(1)+'%'},
+            {'title': 'Entropy', 'data': 'Entropy', 'render': _formatNum},
         ],
         'paging': false,
-        'order': [[1, 'asc']],
+        'order': [[2, 'asc']],
         'dom': 't',
+        'bFilter': false,
     })
 
     var _metaDetailsFormat = function(data){
@@ -734,7 +736,7 @@ Selection_Info.prototype.update = function(updates)
     self.cell_count_span.text(selected_cells.length)
 
     return api.cells.meta(selected_cells).then(result => {
-
+        
         // Rebuild meta-data table
         var dataSet = _.map(result.numeric, function(v, k){
             return [k, v['Min'], v['Median'], v['Max']]
@@ -745,17 +747,19 @@ Selection_Info.prototype.update = function(updates)
             .draw()
 
         var dataSetMeta = _.map(result.factor, function(value, property){
-            var levels = _(value)
+            var levels = _(value.levels)
                 .map(
                     function(percent, level){ return [level, percent] })
                 .orderBy(1, 'desc')
                 .value()
-
+            
             var top = levels[0]
+            var entropy = value.entropy
             return {
                 'Variable': property,
                 'TopValue': top[0],
                 'Percent': top[1],
+                'Entropy': entropy,
                 'OtherLevels': levels,
             }
         })


### PR DESCRIPTION
I've implemented a new feature into the user report for quantifying the entropy of categorical variables within a selection. This is reported in the Selection Table in the lower-left-content div when a selection is made.

This is useful, for example, if you would like to know how 'homogenous' a selected clade is with respect to the transcriptional space.

As such, I have also changed the pipeline to always compute clusters on the transcriptional space as this is necessary regardless to assess the entropy of a selection.

The logic for the entropy calculation is in `R/Server.R`, and the UI changes are in `inst/html_report/src/lower-left-content.js`. 