### PR TITLE
Add ‘phytools’ dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Imports:
 	vegan,
 	ape,
 	reticulate,
-	wordspace
+	wordspace,
+	phytools
 LinkingTo: Rcpp
 License: MIT + file LICENSE
 Encoding: UTF-8


### PR DESCRIPTION
When installing from github, we get an error along the lines of "there is no package called ‘phytools’". It seems like there is an import from phytools, but the dependency is not declared on phytools in DESCRIPTION. This PR fixes that. 