### PR TITLE
added seurat import in data handler

### DIFF
--- a/R/methods-Vision.R
+++ b/R/methods-Vision.R
@@ -596,6 +596,8 @@ setMethod("Vision", signature(data = "Seurat"),
                        call. = FALSE)
               }
 
+              library(Seurat)
+              
               obj <- data
               args <- list(...)
 


### PR DESCRIPTION
Adds a single line importing Seurat before using a Seurat object to populate a VISION object.